### PR TITLE
updated GitHub Actions workflow for package deployment

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,4 +1,4 @@
-name: Build and upload to PyPi
+name: Build and Deploy Package
 
 on:
   push:
@@ -9,45 +9,183 @@ on:
       - published
 
 jobs:
-  test_pypi_push:
-    environment:
-      name: deploy
-      url: https://test.pypi.org/p/mdpow-molconfgen
-    permissions:
-      id-token: write
+  build:
+    name: Build package
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+
+      - name: Build package (binary wheel and source distribution package)
+        run: |
+          python -m build
+
+      - name: Check package
+        run: |
+          twine check dist/*
+
+      - name: Upload dist files
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-files
+          path: dist/
+          retention-days: 1
+
+  test-install:
+    name: Test package installation
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Download dist files
+        uses: actions/download-artifact@v4
+        with:
+          name: dist-files
+          path: dist/
+
+      - name: Install package
+        run: |
+          python -m pip install --upgrade pip
+          pip install dist/*.whl
+
+      - name: Test import
+        run: |
+          python -c "import molconfgen; print('Package imported successfully')"
+
+  test-pytest:
+    name: Run tests
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Download dist files
+        uses: actions/download-artifact@v4
+        with:
+          name: dist-files
+          path: dist/
+
+      - name: Install package with test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          WHEEL_FILE=$(ls dist/*.whl)
+          pip install "$WHEEL_FILE"[test]
+
+      - name: Run tests
+        run: |
+          pytest -n auto --verbose --pyargs molconfgen
+
+  deploy-testpypi:
+    name: Deploy to TestPyPI
+    runs-on: ubuntu-latest
+    needs: [build, test-install, test-pytest]
     if: |
       github.repository == 'Becksteinlab/mdpow-molconfgen' &&
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
-    name: Build, upload and test pure Python wheels to TestPypi
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: testpypi_deploy
-        uses: MDAnalysis/pypi-deployment@main
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
-        with:
-          test_submission: true
-          package_name: 'molconfgen'
-
-  pypi_push:
     environment:
-      name: deploy
-      url: https://pypi.org/p/mdpow-molconfgen
+      name: testpypi
+      url: https://test.pypi.org/p/mdpow-molconfgen
     permissions:
-      id-token: write
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+    steps:
+      - name: Download dist files
+        uses: actions/download-artifact@v4
+        with:
+          name: dist-files
+          path: dist/
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@v1.12.4
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+  deploy-pypi:
+    name: Deploy to PyPI
+    runs-on: ubuntu-latest
+    needs: [build, test-install, test-pytest]
     if: |
       github.repository == 'Becksteinlab/mdpow-molconfgen' &&
       (github.event_name == 'release' && github.event.action == 'published')
-    name: Build, upload and test pure Python wheels to PyPi
-    runs-on: ubuntu-latest
-
+    environment:
+      name: pypi
+      url: https://pypi.org/p/mdpow-molconfgen
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
     steps:
-      - uses: actions/checkout@v4
-
-      - name: pypi_deploy
-        uses: MDAnalysis/pypi-deployment@main
-        if: github.event_name == 'release' && github.event.action == 'published'
+      - name: Download dist files
+        uses: actions/download-artifact@v4
         with:
-          package_name: 'molconfgen'
+          name: dist-files
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.12.4
+
+  test-deployed-testpypi:
+    name: Test deployed package (TestPyPI)
+    runs-on: ubuntu-latest
+    needs: deploy-testpypi
+    if: |
+      github.repository == 'Becksteinlab/mdpow-molconfgen' &&
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install from TestPyPI
+        run: |
+          python -m pip install --upgrade pip
+          pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ mdpow-molconfgen[test]
+
+      - name: Test import
+        run: |
+          python -c "import molconfgen; print('Package imported successfully from TestPyPI')"
+
+      - name: Run basic tests
+        run: |
+          python -c "import molconfgen; print('Package version:', molconfgen.__version__)"
+
+  test-deployed-pypi:
+    name: Test deployed package (PyPI)
+    runs-on: ubuntu-latest
+    needs: deploy-pypi
+    if: |
+      github.repository == 'Becksteinlab/mdpow-molconfgen' &&
+      (github.event_name == 'release' && github.event.action == 'published')
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install from PyPI
+        run: |
+          python -m pip install --upgrade pip
+          pip install mdpow-molconfgen[test]
+
+      - name: Test import
+        run: |
+          python -c "import molconfgen; print('Package imported successfully from PyPI')"
+
+      - name: Run basic tests
+        run: |
+          python -c "import molconfgen; print('Package version:', molconfgen.__version__)"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -82,6 +82,11 @@ jobs:
           name: dist-files
           path: dist/
 
+      - name: Install system dependencies (GROMACS)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gromacs
+
       - name: Install package with test dependencies
         run: |
           python -m pip install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Generation of conformers of small molecules.
 
 
 ### Initial testing systems ###
-From the [COW dataset](https://github.com/Becksteinlab/sampl5-distribution-water-cyclohexane/tree/master/11_validation_dataset92): 
+From the [COW dataset](https://github.com/Becksteinlab/cow-dataset): 
 
 - V36-methylacetate : 1 dihedral
 - V46-2-methyl-1-nitrobenzene : steric hindrance
@@ -47,7 +47,17 @@ If possible, we strongly recommend that you use
 Below we provide instructions both for `mamba` and
 for `pip`.
 
-#### With mamba
+Note that for some functionality you also need a working [GROMACS](https://www.gromacs.org) installation.
+
+#### With pip from PyPi
+
+You can directly install the [mdpow-molconfgen package](https://pypi.org/project/mdpow-molconfgen/) PyPi package with
+```
+pip install mdpow-molconfgen
+```
+This will install all dependencies (except GROMACS).
+
+#### With mamba from source
 
 Ensure that you have [mamba](https://mamba.readthedocs.io/en/latest/installation/mamba-installation.html) installed.
 
@@ -83,7 +93,7 @@ And when you are finished, you can exit the virtual environment with:
 mamba deactivate
 ```
 
-#### With pip
+#### With pip from source
 
 To build the package from source, run:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ readme = "README.md"
 requires-python = ">=3.9"
 dependencies = [
     "MDAnalysis>=2.0.0",
+    "pyedr",
     "rdkit",
     "numpy",
     "tqdm",
@@ -44,9 +45,9 @@ doc = [
     "sphinx_rtd_theme",
 ]
 
-# [project.urls]
-# source = "https://github.com/becksteinlab/mdpow-molconfgen"
-# documentation = "https://mdpow-molconfgen.readthedocs.io"
+[project.urls]
+source = "https://github.com/becksteinlab/mdpow-molconfgen"
+documentation = "https://mdpow-molconfgen.readthedocs.io"
 
 [tool.setuptools]
 packages = ["molconfgen", "molconfgen.tests", "molconfgen.data"]


### PR DESCRIPTION
Fixes #10

Changes made in this Pull Request:
- Renamed workflow to "Build and Deploy Package"
- Split deployment into distinct jobs: build, test-install, test-pytest, deploy-testpypi, and deploy-pypi
- Added steps for building, checking, and uploading package artifacts
- Implemented testing of package installation from TestPyPI and PyPI
- Enhanced environment setup and permissions for deployment jobs
- added missing pyedr dependency
- updated installation instructions in README

PR Checklist
------------
 - [ ] Tests?
 - [x] Docs?
 - [ ] CHANGELOG updated?
 - [x] Issue raised/referenced?
